### PR TITLE
Update CategoricalArrays.jl to 0.9

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -89,7 +89,7 @@ version = "3.2.0"
 deps = ["DataAPI", "Future", "JSON", "Missings", "Printf", "Statistics", "Unicode"]
 git-tree-sha1 = "a6c17353ee38ddab30e73dcfaa1107752de724ec"
 uuid = "324d7699-5711-5eae-9e2f-1d82baa6b597"
-version = "0.8.1"
+version = "0.9"
 
 [[Clustering]]
 deps = ["Distances", "LinearAlgebra", "NearestNeighbors", "Printf", "SparseArrays", "Statistics", "StatsBase"]


### PR DESCRIPTION
Addresses https://github.com/alan-turing-institute/MLJ.jl/issues/691: updates CategoricalArrays.jl to 0.9.

Tested by:

- Running `grep` to find '.jl' files with the keyword "categorical" and manually confirming that the Symbol type is not used (and that Strings were used) in Categorical Arrays.
- Changing the version of CategoricalArrays from `0.8.1` to `0.9` in the `Manifest.toml` file and running `serve()` from Franklin.